### PR TITLE
multistaged build for spark_driver reduces image size

### DIFF
--- a/spark/Dockerfile
+++ b/spark/Dockerfile
@@ -1,14 +1,16 @@
-FROM ubuntu:20.04
+FROM ubuntu:20.04 as base
 ENV DEBIAN_FRONTEND noninteractive
 RUN ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
 RUN apt update && apt install -y wget tar sudo default-jre curl unzip
-RUN wget https://downloads.apache.org/spark/spark-3.1.2/spark-3.1.2-bin-hadoop3.2.tgz
-RUN tar xvfz spark-3.1.2-bin-hadoop3.2.tgz
+RUN wget https://downloads.apache.org/spark/spark-3.1.3/spark-3.1.3-bin-hadoop3.2.tgz
+RUN tar xvfz spark-3.1.3-bin-hadoop3.2.tgz
 RUN wget https://dl.k8s.io/v1.21.0/kubernetes-client-linux-amd64.tar.gz
 RUN tar xvfz kubernetes-client-linux-amd64.tar.gz
 RUN chmod 755 kubernetes/client/bin/kubectl
-RUN mv kubernetes/client/bin/kubectl /bin/
-RUN rm -Rf kubernetes
-RUN rm kubernetes-client-linux-amd64.tar.gz
-WORKDIR /spark-3.1.2-bin-hadoop3.2
 
+FROM ubuntu:20.04 as spark
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt update && apt install -y sudo default-jre
+COPY --from=base kubernetes/client/bin/kubectl /bin/
+COPY --from=base /spark-3.1.3-bin-hadoop3.2 ./spark-3.1.3-bin-hadoop3.2
+WORKDIR /spark-3.1.3-bin-hadoop3.2


### PR DESCRIPTION
I stumbled upon this repo when doing the "Big Data, Hadoop, and Spark Basics" course on edX   
The thing is that `RUN rm ...` doesn't help to make the images smaller cause it creates yet another layer leaving the previous one in the image   
I propose the following changes to the Dockerfile to make the multistage build and consequently to make the resulting image considerably smaller  
Note that you'll have to change the build.sh correspondingly to use the target argument `--target spark`   
Also note that I had to change to spark-3.1.3 since spark-3.1.2 is not available any more from apache.org

I checked that the proposed changes work 
1.  I built the image using `docker build --target spark -t wr0ngc0degen/spark_driver .`
2. I pushed the image built with this Dockerfile to https://hub.docker.com/r/wr0ngc0degen/spark_driver (that's my identity on dockerhub)
3. I replaced the line `image: romeokienzler/spark_driver:3.1.2` --> `image: wr0ngc0degen/spark_driver`
4. I ran the "Apache Spark on Kubernetes Lab" with the updates and everything worked as expected